### PR TITLE
Registers Schoology as a strategy manually

### DIFF
--- a/lib/omniauth-schoology.rb
+++ b/lib/omniauth-schoology.rb
@@ -1,1 +1,2 @@
-require "omniauth/schoology"
+require 'omniauth/schoology/version'
+require 'omniauth/strategies/schoology'

--- a/lib/omniauth/schoology.rb
+++ b/lib/omniauth/schoology.rb
@@ -1,2 +1,0 @@
-require 'omniauth/schoology/version'
-require 'omniauth/strategies/schoology'

--- a/lib/omniauth/strategies/schoology.rb
+++ b/lib/omniauth/strategies/schoology.rb
@@ -3,7 +3,7 @@ require 'omniauth-oauth'
 module OmniAuth
   module Strategies
     class Schoology < OmniAuth::Strategies::OAuth
-      option :name , 'schoology'
+      option :name, 'schoology'
 
       option :client_options, {
         http_method: 'get',
@@ -53,4 +53,10 @@ module OmniAuth
       end
     end
   end
+end
+
+# This is a hack to ensure this Strategy is added to Strategies since OAuth gem (unlike OAuth2 gem) does not call .included when it is inherited.
+#
+unless OmniAuth.strategies.include?(OmniAuth::Strategies::Schoology)
+  OmniAuth::Strategy.included(OmniAuth::Strategies::Schoology)
 end


### PR DESCRIPTION
This fixes an issue where the omniauth test harness didn't register the gem as a strategy.